### PR TITLE
GameEngine process subscriptions correctly

### DIFF
--- a/src/scenes/SceneManager.cpp
+++ b/src/scenes/SceneManager.cpp
@@ -60,8 +60,8 @@ void SceneManager::UpdateSceneManager() {
   // process subscriptions, [TODO: handle potential failure]
   auto process_result = ProcessSubscriptions();
 
-  // // update all scenes
-  // UpdateScenes();
+  // update all scenes
+  UpdateScenes();
 }
 /////////////////////////////////////////////////
 std::expected<std::monostate, FailInfo>

--- a/src/systems/GameEngine.h
+++ b/src/systems/GameEngine.h
@@ -137,6 +137,16 @@ public:
   /// @brief Returns all registered subscribers for inspection
   /////////////////////////////////////////////////
   const std::vector<std::shared_ptr<Subscriber>> &GetSubscriptions() const;
+
+  /////////////////////////////////////////////////
+  /// @brief Go through all subscriptions, if active call relevant Logic
+  /////////////////////////////////////////////////
+  std::expected<std::monostate, FailInfo> ProcessSubscriptions();
+
+  /////////////////////////////////////////////////
+  /// @brief Returns a constant reference to the RenderWindow
+  /////////////////////////////////////////////////
+  const sf::RenderWindow &GetWindow() const;
 };
 
 } // namespace steamrot


### PR DESCRIPTION
- ProcessSubscriptions quits game if correct event is present but not if other events are present
- RunGameLoop incorporates this and game will quite of correct Subscription is active