### PR TITLE
Subscribers set to inactive after processing

### DIFF
--- a/src/logic/UIActionLogic.cpp
+++ b/src/logic/UIActionLogic.cpp
@@ -56,6 +56,9 @@ void ProcessUIActionsAndEvents(UIElement &ui_element,
           dynamic_cast<ButtonElement *>(&ui_element)) {
     ProcessButtonElementActions(*button_element, event_handler);
   }
+
+  // FINALLY set the subscriber to inactive
+  auto set_inactive_result = ui_element.subscription.value()->SetInactive();
 }
 
 /////////////////////////////////////////////////

--- a/src/scenes/SceneManager.cpp
+++ b/src/scenes/SceneManager.cpp
@@ -302,6 +302,8 @@ std::expected<std::monostate, FailInfo> SceneManager::ProcessSubscriptions() {
       default:
         break;
       }
+      // FINAL PART: set subscriber to inactive after processing.
+      auto set_inactive_result = subscriber->SetInactive();
     }
   }
   return std::monostate{};

--- a/src/systems/GameEngine.cpp
+++ b/src/systems/GameEngine.cpp
@@ -204,6 +204,9 @@ std::expected<std::monostate, FailInfo> GameEngine::ProcessSubscriptions() {
       default:
         break;
       }
+
+      // FINALLY set the subscriber to inactive
+      auto set_inactive_result = subscriber->SetInactive();
     }
   }
   return std::monostate{};

--- a/tests/systems/GameEngine.test.cpp
+++ b/tests/systems/GameEngine.test.cpp
@@ -271,3 +271,35 @@ TEST_CASE("GameEngine::ProcessSubscriptions does not quit if another "
   // check that the window is still open
   REQUIRE(game_engine.GetWindow().isOpen());
 }
+
+// check subscribers are set to inactive at end of game loop
+TEST_CASE("GameEngine::ProcessSubscriptions sets subscribers to inactive after "
+          "processing",
+          "[GameEngine]") {
+  // create and pre-initialize PathProvider
+  steamrot::PathProvider path_provider(steamrot::EnvironmentType::Test);
+  // Create a GameEngine instance
+  steamrot::GameEngine game_engine(steamrot::EnvironmentType::Test);
+  // Create and register a Subscriber for EventType_EVENT_CHANGE_SCENE
+  auto subscriber = std::make_shared<steamrot::Subscriber>(
+      steamrot::EventType_EVENT_CHANGE_SCENE);
+  auto register_result = game_engine.RegisterSubscriber(subscriber);
+  if (!register_result.has_value()) {
+    FAIL("Failed to register subscriber: " + register_result.error().message);
+  }
+  // check that the window is open initially
+  REQUIRE(game_engine.GetWindow().isOpen());
+  // Activate the Subscriber
+  auto set_active_result = subscriber->SetActive();
+  if (!set_active_result.has_value()) {
+    FAIL("Failed to activate subscriber: " + set_active_result.error().message);
+  }
+  // Process subscriptions in GameEngine
+  auto process_subscriptions_result = game_engine.ProcessSubscriptions();
+  if (!process_subscriptions_result.has_value()) {
+    FAIL("Failed to process subscriptions: " +
+         process_subscriptions_result.error().message);
+  }
+  // check that the subscriber is now inactive
+  REQUIRE(!subscriber->IsActive());
+}


### PR DESCRIPTION
- Subscribers set to inactive in SceneManager, GameEngine and UIActionLogic. 
- Depending on how the system evolves it may be worth just looping over all of them in once place (maybe the EventHandler), this will depend on how many we get